### PR TITLE
Fix race condition in deep linking

### DIFF
--- a/lib/platforms/react-native.js
+++ b/lib/platforms/react-native.js
@@ -1,21 +1,31 @@
 import { Linking } from 'react-native'; // eslint-disable-line import/no-unresolved, max-len
 
-export const dance = authUrl => Linking.openURL(authUrl)
-  .then(() => new Promise((resolve, reject) => {
-    const handleUrl = (url) => {
-      if (!url || url.indexOf('fail') > -1) {
-        reject(url);
-      } else {
-        resolve(url);
-      }
-    };
+let previousOnLinkChange;
 
-    const onLinkChange = ({ url }) => {
-      Linking.removeEventListener('url', onLinkChange);
-      handleUrl(url);
-    };
+export const dance = (authUrl) => {
+  if (previousOnLinkChange) {
+    Linking.removeEventListener('url', previousOnLinkChange);
+  }
 
-    Linking.addEventListener('url', onLinkChange);
-  }));
+  return Linking.openURL(authUrl)
+    .then(() => new Promise((resolve, reject) => {
+      const handleUrl = (url) => {
+        if (!url || url.indexOf('fail') > -1) {
+          reject(url);
+        } else {
+          resolve(url);
+        }
+      };
+
+      const onLinkChange = ({ url }) => {
+        Linking.removeEventListener('url', onLinkChange);
+        handleUrl(url);
+      };
+
+      Linking.addEventListener('url', onLinkChange);
+
+      previousOnLinkChange = onLinkChange;
+    }));
+};
 
 export const request = fetch;


### PR DESCRIPTION
If a user returns to the app before the oauth login flow completes, a hanging deep link event handler will cause the next oauth flow to trigger two token requests. In the case of google oauth, this will result in an `invalid_grant` error.

Steps to reproduce:
  1. Configure an app to oauth using google
  2. On iOS, trigger an oauth flow and return to the app using the "back-to" button in the status bar
  3. Trigger oauth again and this time complete the flow and click the open button in the dialog to deep link back to your app
  4. You should now see an `invalid_grant` error

This PR fixes this case by ensuring that only a single active deep linking url handler can exist at a time.